### PR TITLE
Updates for default chain and cluster binding for running the tasks

### DIFF
--- a/src/main/java/com/phuna/amazonecs/AWSUtils.java
+++ b/src/main/java/com/phuna/amazonecs/AWSUtils.java
@@ -130,7 +130,7 @@ public class AWSUtils {
 				.getContainerInstanceArn();
 
 		DescribeContainerInstancesResult dcirr = AWSUtils
-				.describeContainerInstances(cloud, containerInstanceArn);
+				.describeContainerInstances(cloud, cluster, containerInstanceArn);
 		if (dcirr.getContainerInstances().size() == 0) {
 			throw new RuntimeException(
 					"No container instances found for task ARN: " + taskArn);

--- a/src/main/java/com/phuna/amazonecs/Constants.java
+++ b/src/main/java/com/phuna/amazonecs/Constants.java
@@ -4,6 +4,6 @@ public class Constants {
 	public static final int RETRIES = 10;
 	public static final int WAIT_TIME_MS = 500;
 	public static final int SSH_PORT = 22;
-	public static final String AWS_ECS_ENDPOINT = "https://ecs.us-west-2.amazonaws.com";
-	public static final String AWS_EC2_ENDPOINT = "https://ec2.us-west-2.amazonaws.com";
+	public static final String AWS_ECS_ENDPOINT = "https://ecs.eu-west-1.amazonaws.com";
+	public static final String AWS_EC2_ENDPOINT = "https://ec2.eu-west-1.amazonaws.com";
 }

--- a/src/main/java/com/phuna/amazonecs/EcsDockerComputerLauncher.java
+++ b/src/main/java/com/phuna/amazonecs/EcsDockerComputerLauncher.java
@@ -58,7 +58,7 @@ public class EcsDockerComputerLauncher extends DelegatingComputerLauncher {
 		AwsCloud cloud = template.getParent();
 		
 		// Wait until container's status becomes RUNNING
-		Container ctn = AWSUtils.waitForContainer(cloud, taskArn);
+		Container ctn = AWSUtils.waitForContainer(cloud, template.getClusterName(), taskArn);
 		if (!ctn.getLastStatus().equals("RUNNING")) {
 			throw new RuntimeException("Container takes too long time to start");
 		}
@@ -78,23 +78,23 @@ public class EcsDockerComputerLauncher extends DelegatingComputerLauncher {
 
 		if (host == "" || port == -1) {
 			logger.warning("Failed to connect to the container");
-			AWSUtils.stopTask(cloud, taskArn, template.getParent().isSameVPC());
+			AWSUtils.stopTask(cloud,template.getClusterName(), taskArn, template.getParent().isSameVPC());
 			throw new RuntimeException("Cannot determine host/port to SSH into");
 		}
 
 		// host = "54.187.124.238";
 //		host = "172.31.4.94";
-		logger.info("container's private IP = " + AWSUtils.getTaskContainerPrivateAddress(cloud, taskArn));
-		logger.info("container's public IP = " + AWSUtils.getTaskContainerPublicAddress(cloud, taskArn));
+		logger.info("container's private IP = " + AWSUtils.getTaskContainerPrivateAddress(cloud, template.getClusterName(),taskArn));
+		logger.info("container's public IP = " + AWSUtils.getTaskContainerPublicAddress(cloud, template.getClusterName(),taskArn));
 //		if (host.equals("0.0.0.0")) {
 //			host = CommonUtils.getTaskContainerPublicAddress(taskArn);
 //		}
 		if (template.getParent().isSameVPC()) {
 			logger.info("Use private address");
-			host = AWSUtils.getTaskContainerPrivateAddress(cloud, taskArn);
+			host = AWSUtils.getTaskContainerPrivateAddress(cloud, template.getClusterName(),taskArn);
 		} else {
 			logger.info("Use public address");
-			host = AWSUtils.getTaskContainerPublicAddress(cloud, taskArn);
+			host = AWSUtils.getTaskContainerPublicAddress(cloud,template.getClusterName(), taskArn);
 		}
 
 		logger.info("Creating slave SSH launcher for " + host + ":" + port);

--- a/src/main/java/com/phuna/amazonecs/EcsDockerSlave.java
+++ b/src/main/java/com/phuna/amazonecs/EcsDockerSlave.java
@@ -42,7 +42,7 @@ public class EcsDockerSlave extends AbstractCloudSlave {
 			InterruptedException {
 		toComputer().disconnect(null);
 		logger.info("Stop task " + taskArn);
-		AWSUtils.stopTask(template.getParent(), taskArn, template.getParent().isSameVPC());
+		AWSUtils.stopTask(template.getParent(), taskArn,template.getClusterName(), template.getParent().isSameVPC());
 	}
 
 }

--- a/src/main/java/com/phuna/amazonecs/EcsTaskTemplate.java
+++ b/src/main/java/com/phuna/amazonecs/EcsTaskTemplate.java
@@ -208,7 +208,7 @@ public class EcsTaskTemplate implements Describable<EcsTaskTemplate> {
 		RunTaskResult result = client.runTask(request);
 		logger.warning("Run Task Result : Failures : "+result.getFailures().size()+" tasks="+result.getTasks().size()+" RunTaskResult="+result.toString());
 		
-		return client.runTask(request);
+		return result;
 	}
 
 	@Override

--- a/src/main/resources/com/phuna/amazonecs/EcsCloud/config.jelly
+++ b/src/main/resources/com/phuna/amazonecs/EcsCloud/config.jelly
@@ -3,19 +3,27 @@
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:c="/lib/credentials">
 	
-	<f:entry title="${%Name}">
+	<f:entry title="${%Name}" description="${%Cloud Name}">
 		<f:textbox field="name" />
 	</f:entry>
 	
-	<f:entry title="${%Access Key ID}">
+	<f:entry title="${%Access Key ID}" description="${%Leave blank if you want to use default aws credentials chain}">
 		<f:textbox field="accessKeyId" />
 	</f:entry>
-	<f:entry title="${%Secret Access Key}">
+	<f:entry title="${%Secret Access Key}" description="${%Leave blank if you want to use default aws credentials chain}">
 		<f:password field="secretAccessKey"/>
 	</f:entry>
 	
+	<f:entry title="${%EC2 End Point}" description="${%Default is https://ec2.eu-west-1.amazonaws.com}">
+		<f:textbox field="ec2EndPoint"/>
+	</f:entry>
+	
+	<f:entry title="${%ECS End Point}" description="${%Default is https://ecs.eu-west-1.amazonaws.com}">
+		<f:textbox field="ecsEndPoint"/>
+	</f:entry>
+	
 	<f:validateButton title="${%Test Connection}"
-		progress="${%Testing...}" method="testConnection" with="accessKeyId,secretAccessKey" />
+		progress="${%Testing...}" method="testConnection" with="accessKeyId,secretAccessKey,ecsEndPoint" />
 	<f:entry title="${%Same Virtual Private Cloud}">
 		<f:checkbox field="sameVPC" />
 	</f:entry>

--- a/src/main/resources/com/phuna/amazonecs/EcsTaskTemplate/template.jelly
+++ b/src/main/resources/com/phuna/amazonecs/EcsTaskTemplate/template.jelly
@@ -3,7 +3,9 @@
 	<f:entry title="${%Task definition Arn}" field="taskDefinitionArn">
 		<f:textbox />
 	</f:entry>
-
+	<f:entry title="${%Cluster Name}" description="${%Cluster Name where this task should run. Leave blank for default}">
+		<f:textbox field="clusterName" />
+	</f:entry>
 	<f:entry title="${%Labels}" field="labelString">
 		<f:textbox />
 	</f:entry>


### PR DESCRIPTION
So here is the pull request that has more updates then I expected.
1. It now allows the user to leave the credential blank and the EC2Client and ECSClient use the DefaultAWSCredentialsProviderChain.
2. I added the option to run the task on a given cluster. So in the task template you can now specify the cluster to run the task.
3. I have also added the option for the user to specify the aws endpoints via the configuration instead of env variable.

I have done very limited tested only by using it on my own cluster. Will do more testing.
thanks
Ali
